### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 1
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.2, 8.3, 8.4 ]
+        php: [ 8.2, 8.3, 8.4, 8.5 ]
         laravel: [ 12.* ]
         stability: [ prefer-lowest, prefer-stable ]
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "8.2.*|8.3.*|8.4.*",
+        "php": "8.2.*|8.3.*|8.4.*|8.5.*",
         "guzzlehttp/guzzle": "^7.8",
         "illuminate/contracts": "^12.0",
         "spatie/laravel-package-tools": "^1.19",

--- a/src/DTO/Ticket.php
+++ b/src/DTO/Ticket.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
+#[\AllowDynamicProperties]
 class Ticket
 {
     public static function fromJson(array $data, bool $expanded = false): self


### PR DESCRIPTION
## Summary

Adds PHP 8.5 to the list of supported PHP versions. Closes #54.

The package source itself was already compatible with PHP 8.5. The only blocker
was the artificial upper bound in the `php` constraint, together with the CI
matrix not exercising 8.5. This PR widens the constraint, extends CI, and clears
the one pre-existing deprecation that would otherwise become a fatal error in
PHP 9.0.

## Changes

1. `composer.json`: widen the `php` constraint from `8.2.*|8.3.*|8.4.*` to
   `8.2.*|8.3.*|8.4.*|8.5.*`.
2. `.github/workflows/run-tests.yml`: add `8.5` to the test matrix.
3. `src/DTO/Ticket.php`: mark the class with `#[\AllowDynamicProperties]`.

The `Ticket` DTO assigns config-driven attributes as dynamic properties
(`$this->$name = $value`). The property names come from the user-configurable
`zammad.ticket` map and cannot be declared ahead of time. This already emits an
`E_DEPRECATED` notice on PHP 8.2 and later, and becomes a fatal error in PHP 9.0.
Adding `#[\AllowDynamicProperties]` is the conservative, non-breaking fix. The
attribute exists since PHP 8.2, so it is safe on every supported version and
changes no behavior beyond suppressing the deprecation.

## Verification (PHP 8.5.7, Composer 2.10.1)

* `composer update` resolves cleanly. All production dependencies admit 8.5.
* `php -l` reports no syntax errors across `src`.
* PHPStan (larastan) passes with no errors.
* The DTO test suite passes, including the dynamic-attributes test that
  exercises the `Ticket` property path.

## Notes for reviewers

* `composer update` on 8.5 also upgrades `saloonphp/saloon` from v3 to v4, which
  is already permitted by the existing `^3.0|^4.0` constraint. Static analysis
  and the DTO layer are clean against v4. The HTTP integration tests run against
  a live Zammad instance (they require `ZAMMAD_URL` and `ZAMMAD_TOKEN`), so the
  CI run with the configured secrets is the authoritative check for that layer.
* `composer.lock` is gitignored, so no lock file changes are included in this PR.