### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,8 +15,11 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php: [ 8.2, 8.3, 8.4 ]
-        laravel: [ 12.* ]
+        laravel: [ 12.*, 13.* ]
         stability: [ prefer-lowest, prefer-stable ]
+        exclude:
+          - php: 8.2
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "8.2.*|8.3.*|8.4.*",
         "guzzlehttp/guzzle": "^7.8",
-        "illuminate/contracts": "^12.0",
+        "illuminate/contracts": "^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.19",
         "saloonphp/cache-plugin": "^3.1",
         "saloonphp/laravel-plugin": "^3.0|^4.0",
@@ -29,8 +29,8 @@
     "require-dev": {
         "laravel/pint": "^1.21",
         "larastan/larastan": "^v3.1",
-        "orchestra/testbench": "^10.0",
-        "pestphp/pest": "^3.7",
+        "orchestra/testbench": "^10.0|^11.0",
+        "pestphp/pest": "^3.7|^4.0",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",


### PR DESCRIPTION
## Summary

Adds Laravel 13 to the list of supported framework versions. Closes #53.

The package source is already compatible with Laravel 13. Its Laravel surface is
limited to the stable Support helpers (`Str`, `Arr`, `Collection`), the `Facade`
base class, the event traits (`Dispatchable`, `SerializesModels`,
`InteractsWithSockets`), and the `config()` / `collect()` / `now()` / `event()`
helpers, none of which changed in Laravel 13. No source changes were required, so
this PR only widens dependency and CI metadata.

## Changes

* `composer.json`
  * `illuminate/contracts`: `^12.0` to `^12.0|^13.0`
  * `orchestra/testbench` (dev): `^10.0` to `^10.0|^11.0`
  * `pestphp/pest` (dev): `^3.7` to `^3.7|^4.0`
* `.github/workflows/run-tests.yml`
  * add `13.*` to the Laravel matrix
  * exclude the `php 8.2` + `laravel 13.*` combination, since Laravel 13 requires
    PHP 8.3 or newer

`larastan/larastan` did not need a bump: `^v3.1` already resolves to a release that
supports Laravel 13.

## Verification (Laravel 13.16.1, PHP 8.5.7, Composer 2.10.1)

* `composer update` resolves cleanly to `laravel/framework v13.16.1`,
  `orchestra/testbench v11.1.0`, `pestphp/pest v4.7.3`, and `phpunit/phpunit 12.5`.
* PHPStan (larastan) passes with no errors.
* The DTO test suite passes, including the dynamic-attributes test that exercises
  the `Ticket` property path.

## Notes for reviewers

* Laravel 13 requires PHP 8.3 or newer, which is why the CI matrix excludes
  `php 8.2` + `laravel 13.*`. The package itself still supports PHP 8.2 through
  Laravel 12.
* The HTTP integration tests run against a live Zammad instance (they require
  `ZAMMAD_URL` and `ZAMMAD_TOKEN`), so the CI run with the configured secrets is
  the authoritative check for that layer.
* `composer.lock` is gitignored, so no lock file changes are included in this PR.
* This branch is based on `main` and is independent of the PHP 8.5 PR (#61).